### PR TITLE
Add reset functionality

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -25,4 +25,15 @@ document.addEventListener('DOMContentLoaded', () => {
   // Initialize displays
   onRoleChange();
   onGroupChange();
+
+  function resetForm() {
+    roleSelect.selectedIndex = -1;
+    groupSelect.selectedIndex = -1;
+    roleDisplay.className = 'color-box';
+    groupDisplay.className = 'color-box';
+    roleDisplay.removeAttribute('style');
+    groupDisplay.removeAttribute('style');
+  }
+
+  window.resetForm = resetForm;
 });

--- a/src/index.html
+++ b/src/index.html
@@ -29,6 +29,8 @@
       </select>
       <div id="group-display" class="color-box"></div>
     </div>
+
+    <button type="button" onclick="resetForm()">Reset</button>
   </div>
 
   <script src="app.js"></script>


### PR DESCRIPTION
## Summary
- allow form reset by adding resetForm() and hooking it up to a new button

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_688f9d56780c832693b5875302e93ac4