### PR TITLE
Add Jest tests for color mapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "accessmanager",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  },
+  "jest": {
+    "testEnvironment": "jsdom"
+  }
+}

--- a/src/app.js
+++ b/src/app.js
@@ -26,3 +26,7 @@ document.addEventListener('DOMContentLoaded', () => {
   onRoleChange();
   onGroupChange();
 });
+
+if (typeof module !== 'undefined') {
+  module.exports = { updateColor };
+}

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -1,0 +1,23 @@
+const { updateColor } = require('../src/app');
+
+describe('updateColor', () => {
+  test('maps value to corresponding class', () => {
+    const element = {
+      className: 'color-box role-user',
+      classList: { add: jest.fn() },
+    };
+    updateColor(element, 'role-', 'admin');
+    expect(element.className).toBe('color-box');
+    expect(element.classList.add).toHaveBeenCalledWith('role-admin');
+  });
+
+  test('resets classes when value is empty', () => {
+    const element = {
+      className: 'color-box role-user',
+      classList: { add: jest.fn() },
+    };
+    updateColor(element, 'role-', '');
+    expect(element.className).toBe('color-box');
+    expect(element.classList.add).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- export updateColor for testing
- configure Jest and add tests for color mapping and reset behavior

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_688f9d5f8ed88326b1a7b0b1724bd3d4