### PR TITLE
Load roles and groups from data modules

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,8 +1,8 @@
-function updateColor(element, baseClass, value) {
-  element.className = 'color-box';
-  if (value) {
-    element.classList.add(baseClass + value);
-  }
+import { roles } from './data/roles.js';
+import { groups } from './data/groups.js';
+
+function updateColor(element, color) {
+  element.style.backgroundColor = color || '#ddd';
 }
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -11,18 +11,33 @@ document.addEventListener('DOMContentLoaded', () => {
   const roleDisplay = document.getElementById('role-display');
   const groupDisplay = document.getElementById('group-display');
 
+  roles.forEach((role) => {
+    const option = document.createElement('option');
+    option.value = role.value;
+    option.textContent = role.label;
+    roleSelect.appendChild(option);
+  });
+
+  groups.forEach((group) => {
+    const option = document.createElement('option');
+    option.value = group.value;
+    option.textContent = group.label;
+    groupSelect.appendChild(option);
+  });
+
   function onRoleChange() {
-    updateColor(roleDisplay, 'role-', roleSelect.value);
+    const role = roles.find((r) => r.value === roleSelect.value);
+    updateColor(roleDisplay, role && role.color);
   }
 
   function onGroupChange() {
-    updateColor(groupDisplay, 'group-', groupSelect.value);
+    const group = groups.find((g) => g.value === groupSelect.value);
+    updateColor(groupDisplay, group && group.color);
   }
 
   roleSelect.addEventListener('change', onRoleChange);
   groupSelect.addEventListener('change', onGroupChange);
 
-  // Initialize displays
   onRoleChange();
   onGroupChange();
 });

--- a/src/data/groups.js
+++ b/src/data/groups.js
@@ -1,0 +1,5 @@
+export const groups = [
+  { value: 'a', label: 'Group A', color: '#f1c40f' },
+  { value: 'b', label: 'Group B', color: '#9b59b6' },
+  { value: 'c', label: 'Group C', color: '#e67e22' }
+];

--- a/src/data/roles.js
+++ b/src/data/roles.js
@@ -1,0 +1,5 @@
+export const roles = [
+  { value: 'vjrj', label: 'VJRJ - vaktmenn', color: '#e74c3c' },
+  { value: 'ktpd', label: 'KTPD - kontorpersonale', color: '#3498db' },
+  { value: 'gjst', label: 'GJST - gjester', color: '#2ecc71' }
+];

--- a/src/index.html
+++ b/src/index.html
@@ -12,25 +12,17 @@
 
     <div class="control-group">
       <label for="role-select">User Role:</label>
-      <select id="role-select">
-        <option value="admin">Admin</option>
-        <option value="employee">Employee</option>
-        <option value="visitor">Visitor</option>
-      </select>
+      <select id="role-select"></select>
       <div id="role-display" class="color-box"></div>
     </div>
 
     <div class="control-group">
       <label for="group-select">Door Group:</label>
-      <select id="group-select">
-        <option value="a">Group A</option>
-        <option value="b">Group B</option>
-        <option value="c">Group C</option>
-      </select>
+      <select id="group-select"></select>
       <div id="group-display" class="color-box"></div>
     </div>
   </div>
 
-  <script src="app.js"></script>
+  <script type="module" src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `src/data/roles.js` and `src/data/groups.js`
- dynamically populate dropdowns in `app.js`
- adjust `index.html` to load module script

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688f9d5a884c83268f276cda2f6d281f