### PR TITLE
Add three Door Group selectors to replace User Role

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,50 +1,45 @@
-import { roles } from './data/roles.js';
 import { groups } from './data/groups.js';
 import { updateColor } from './updateColor.js';
 
 document.addEventListener('DOMContentLoaded', () => {
-  const roleSelect = document.getElementById('role-select');
-  const groupSelect = document.getElementById('group-select');
-  const roleDisplay = document.getElementById('role-display');
-  const groupDisplay = document.getElementById('group-display');
+  const group1Select = document.getElementById('group1-select');
+  const group2Select = document.getElementById('group2-select');
+  const group3Select = document.getElementById('group3-select');
+  const group1Display = document.getElementById('group1-display');
+  const group2Display = document.getElementById('group2-display');
+  const group3Display = document.getElementById('group3-display');
 
-  roles.forEach((role) => {
-    const option = document.createElement('option');
-    option.value = role.value;
-    option.textContent = role.label;
-    roleSelect.appendChild(option);
+  [group1Select, group2Select, group3Select].forEach((select) => {
+    groups.forEach((group) => {
+      const option = document.createElement('option');
+      option.value = group.value;
+      option.textContent = group.label;
+      select.appendChild(option);
+    });
   });
 
-  groups.forEach((group) => {
-    const option = document.createElement('option');
-    option.value = group.value;
-    option.textContent = group.label;
-    groupSelect.appendChild(option);
-  });
-
-  function onRoleChange() {
-    const role = roles.find((r) => r.value === roleSelect.value);
-    updateColor(roleDisplay, role && role.color);
+  function onGroupChange(select, display) {
+    const group = groups.find((g) => g.value === select.value);
+    updateColor(display, group && group.color);
   }
 
-  function onGroupChange() {
-    const group = groups.find((g) => g.value === groupSelect.value);
-    updateColor(groupDisplay, group && group.color);
-  }
+  group1Select.addEventListener('change', () => onGroupChange(group1Select, group1Display));
+  group2Select.addEventListener('change', () => onGroupChange(group2Select, group2Display));
+  group3Select.addEventListener('change', () => onGroupChange(group3Select, group3Display));
 
-  roleSelect.addEventListener('change', onRoleChange);
-  groupSelect.addEventListener('change', onGroupChange);
-
-  onRoleChange();
-  onGroupChange();
+  onGroupChange(group1Select, group1Display);
+  onGroupChange(group2Select, group2Display);
+  onGroupChange(group3Select, group3Display);
 
   function resetForm() {
-    roleSelect.selectedIndex = -1;
-    groupSelect.selectedIndex = -1;
-    roleDisplay.className = 'color-box';
-    groupDisplay.className = 'color-box';
-    roleDisplay.removeAttribute('style');
-    groupDisplay.removeAttribute('style');
+    [group1Select, group2Select, group3Select].forEach((select) => {
+      select.selectedIndex = -1;
+    });
+
+    [group1Display, group2Display, group3Display].forEach((display) => {
+      display.className = 'color-box';
+      display.removeAttribute('style');
+    });
   }
 
   window.resetForm = resetForm;

--- a/src/data/roles.js
+++ b/src/data/roles.js
@@ -1,5 +1,0 @@
-export const roles = [
-  { value: 'vjrj', label: 'VJRJ - vaktmenn', color: '#e74c3c' },
-  { value: 'ktpd', label: 'KTPD - kontorpersonale', color: '#3498db' },
-  { value: 'gjst', label: 'GJST - gjester', color: '#2ecc71' }
-];

--- a/src/index.html
+++ b/src/index.html
@@ -11,15 +11,21 @@
     <h1>Access Manager</h1>
 
     <div class="control-group">
-      <label for="role-select">User Role:</label>
-      <select id="role-select"></select>
-      <div id="role-display" class="color-box"></div>
+      <label for="group1-select">Door Group 1:</label>
+      <select id="group1-select"></select>
+      <div id="group1-display" class="color-box"></div>
     </div>
 
     <div class="control-group">
-      <label for="group-select">Door Group:</label>
-      <select id="group-select"></select>
-      <div id="group-display" class="color-box"></div>
+      <label for="group2-select">Door Group 2:</label>
+      <select id="group2-select"></select>
+      <div id="group2-display" class="color-box"></div>
+    </div>
+
+    <div class="control-group">
+      <label for="group3-select">Door Group 3:</label>
+      <select id="group3-select"></select>
+      <div id="group3-display" class="color-box"></div>
     </div>
 
     <button type="button" onclick="resetForm()">Reset</button>

--- a/src/styles.css
+++ b/src/styles.css
@@ -39,11 +39,6 @@ select {
   background-color: #ddd;
 }
 
-/* Role colors */
-.role-admin { background-color: #e74c3c; }
-.role-employee { background-color: #3498db; }
-.role-visitor { background-color: #2ecc71; }
-
 /* Group colors */
 .group-a { background-color: #f1c40f; }
 .group-b { background-color: #9b59b6; }


### PR DESCRIPTION
## Summary
- replace User Role dropdown with Door Group 1
- rename original Door Group to Door Group 2 and add Door Group 3
- simplify styling to remove unused role colors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688fe2117b388326ba93f2ef5f5ee251