### PR TITLE
Add door access visualization to web app

### DIFF
--- a/docs/src/app.js
+++ b/docs/src/app.js
@@ -1,4 +1,5 @@
 import { groups } from './data/groups.js';
+import { doors } from './data/Doorlist.js';
 import { updateColor } from './updateColor.js';
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -8,6 +9,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const group1Display = document.getElementById('group1-display');
   const group2Display = document.getElementById('group2-display');
   const group3Display = document.getElementById('group3-display');
+  const doorList = document.getElementById('door-list');
 
   [group1Select, group2Select, group3Select].forEach((select) => {
     groups.forEach((group) => {
@@ -18,9 +20,45 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 
+  function getSelectedGroups() {
+    return [group1Select.value, group2Select.value, group3Select.value].filter(Boolean);
+  }
+
+  function updateDoorList() {
+    const selected = getSelectedGroups();
+    const accessible = doors.filter((door) => door.groups.some((g) => selected.includes(g)));
+
+    doorList.innerHTML = '';
+    if (accessible.length === 0) {
+      const li = document.createElement('li');
+      li.textContent = 'Select groups to see doors';
+      doorList.appendChild(li);
+      return;
+    }
+
+    accessible.forEach((door) => {
+      const li = document.createElement('li');
+      li.textContent = door.label;
+
+      const indicators = document.createElement('span');
+      indicators.className = 'group-indicators';
+      door.groups.forEach((groupValue) => {
+        if (selected.includes(groupValue)) {
+          const g = groups.find((gr) => gr.value === groupValue);
+          const span = document.createElement('span');
+          span.style.backgroundColor = g.color;
+          indicators.appendChild(span);
+        }
+      });
+      li.appendChild(indicators);
+      doorList.appendChild(li);
+    });
+  }
+
   function onGroupChange(select, display) {
     const group = groups.find((g) => g.value === select.value);
     updateColor(display, group && group.color);
+    updateDoorList();
   }
 
   group1Select.addEventListener('change', () => onGroupChange(group1Select, group1Display));
@@ -30,6 +68,7 @@ document.addEventListener('DOMContentLoaded', () => {
   onGroupChange(group1Select, group1Display);
   onGroupChange(group2Select, group2Display);
   onGroupChange(group3Select, group3Display);
+  updateDoorList();
 
   function resetForm() {
     [group1Select, group2Select, group3Select].forEach((select) => {
@@ -40,6 +79,8 @@ document.addEventListener('DOMContentLoaded', () => {
       display.className = 'color-box';
       display.removeAttribute('style');
     });
+
+    updateDoorList();
   }
 
   window.resetForm = resetForm;

--- a/docs/src/index.html
+++ b/docs/src/index.html
@@ -29,6 +29,11 @@
     </div>
 
     <button type="button" onclick="resetForm()">Reset</button>
+
+    <div class="door-list">
+      <h2>Accessible Doors</h2>
+      <ul id="door-list"></ul>
+    </div>
   </div>
 
   <script type="module" src="app.js"></script>

--- a/docs/src/styles.css
+++ b/docs/src/styles.css
@@ -39,6 +39,43 @@ select {
   background-color: #ddd;
 }
 
+.door-list {
+  margin-top: 20px;
+}
+
+.door-list ul {
+  list-style: none;
+  padding: 0;
+  max-height: 200px;
+  overflow-y: auto;
+  border: 1px solid #eee;
+  border-radius: 4px;
+}
+
+.door-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 8px;
+  border-bottom: 1px solid #eee;
+  font-size: 14px;
+}
+
+.door-list li:last-child {
+  border-bottom: none;
+}
+
+.group-indicators {
+  display: flex;
+  gap: 4px;
+}
+
+.group-indicators span {
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+}
+
 /* Group colors */
 .group-a { background-color: #f1c40f; }
 .group-b { background-color: #9b59b6; }

--- a/src/updateColor.js
+++ b/src/updateColor.js
@@ -1,0 +1,3 @@
+export function updateColor(element, color) {
+  element.style.backgroundColor = color || '#ddd';
+}


### PR DESCRIPTION
## Summary
- Display accessible doors for up to three selected groups
- Compute door access from data and show color indicators for contributing groups
- Style and structure UI section for the new door list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688fede7cd9c832693c12705c59aea2c