### PR TITLE
Add small padding inside door list

### DIFF
--- a/docs/src/styles.css
+++ b/docs/src/styles.css
@@ -50,7 +50,7 @@ select {
 
 .door-list ul {
   list-style: none;
-  padding: 0;
+  padding: 5px;
   max-height: 800px;
   overflow-y: auto;
   border: 1px solid #eee;


### PR DESCRIPTION
## Summary
- add slight padding to door list container so entries don't touch borders

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688ff98681e48326a20f0ce1e4f8db8b