### PR TITLE
Display grouped door lists

### DIFF
--- a/docs/src/app.js
+++ b/docs/src/app.js
@@ -2,16 +2,52 @@ import { groups } from './data/groups.js';
 import { doors } from './data/Doorlist.js';
 import { updateColor } from './updateColor.js';
 
-document.addEventListener('DOMContentLoaded', () => {
-  const group1Select = document.getElementById('group1-select');
-  const group2Select = document.getElementById('group2-select');
-  const group3Select = document.getElementById('group3-select');
-  const group1Display = document.getElementById('group1-display');
-  const group2Display = document.getElementById('group2-display');
-  const group3Display = document.getElementById('group3-display');
-  const doorList = document.getElementById('door-list');
+const group1Select = document.getElementById('group1-select');
+const group2Select = document.getElementById('group2-select');
+const group3Select = document.getElementById('group3-select');
+const group1Display = document.getElementById('group1-display');
+const group2Display = document.getElementById('group2-display');
+const group3Display = document.getElementById('group3-display');
+const listA = document.getElementById('group-a-doors');
+const listB = document.getElementById('group-b-doors');
+const listC = document.getElementById('group-c-doors');
 
+function populateDoorLists() {
+  const lists = { a: listA, b: listB, c: listC };
+  Object.entries(lists).forEach(([groupValue, ul]) => {
+    ul.innerHTML = '';
+    doors
+      .filter((door) => door.groups.includes(groupValue))
+      .forEach((door) => {
+        const li = document.createElement('li');
+        li.textContent = door.label;
+        ul.appendChild(li);
+      });
+  });
+}
+
+function onGroupChange(select, display) {
+  const group = groups.find((g) => g.value === select.value);
+  updateColor(display, group && group.color);
+}
+
+function resetForm() {
   [group1Select, group2Select, group3Select].forEach((select) => {
+    select.value = '';
+  });
+
+  [group1Display, group2Display, group3Display].forEach((display) => {
+    updateColor(display, '');
+  });
+}
+
+function init() {
+  [group1Select, group2Select, group3Select].forEach((select) => {
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = '';
+    select.appendChild(placeholder);
+
     groups.forEach((group) => {
       const option = document.createElement('option');
       option.value = group.value;
@@ -20,66 +56,14 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 
-  function getSelectedGroups() {
-    return [group1Select.value, group2Select.value, group3Select.value].filter(Boolean);
-  }
-
-  function updateDoorList() {
-    const selected = getSelectedGroups();
-    const accessible = doors.filter((door) => door.groups.some((g) => selected.includes(g)));
-
-    doorList.innerHTML = '';
-    if (accessible.length === 0) {
-      const li = document.createElement('li');
-      li.textContent = 'Select groups to see doors';
-      doorList.appendChild(li);
-      return;
-    }
-
-    accessible.forEach((door) => {
-      const li = document.createElement('li');
-      li.textContent = door.label;
-
-      const indicators = document.createElement('span');
-      indicators.className = 'group-indicators';
-      door.groups.forEach((groupValue) => {
-        if (selected.includes(groupValue)) {
-          const g = groups.find((gr) => gr.value === groupValue);
-          const span = document.createElement('span');
-          span.style.backgroundColor = g.color;
-          indicators.appendChild(span);
-        }
-      });
-      li.appendChild(indicators);
-      doorList.appendChild(li);
-    });
-  }
-
-  function onGroupChange(select, display) {
-    const group = groups.find((g) => g.value === select.value);
-    updateColor(display, group && group.color);
-    updateDoorList();
-  }
-
   group1Select.addEventListener('change', () => onGroupChange(group1Select, group1Display));
   group2Select.addEventListener('change', () => onGroupChange(group2Select, group2Display));
   group3Select.addEventListener('change', () => onGroupChange(group3Select, group3Display));
 
+  populateDoorLists();
   resetForm();
+}
 
-  function resetForm() {
-    [group1Select, group2Select, group3Select].forEach((select) => {
-      select.selectedIndex = -1;
-    });
-
-    [group1Display, group2Display, group3Display].forEach((display) => {
-      display.className = 'color-box';
-      display.removeAttribute('style');
-    });
-
-    updateDoorList();
-  }
-
-  window.resetForm = resetForm;
-});
+init();
+window.resetForm = resetForm;
 

--- a/docs/src/index.html
+++ b/docs/src/index.html
@@ -33,7 +33,18 @@
 
   <div class="container door-list">
     <h2>Aðgengi:</h2>
-    <ul id="door-list"></ul>
+    <div class="door-group">
+      <h3>Hurðir í A flokki:</h3>
+      <ul id="group-a-doors"></ul>
+    </div>
+    <div class="door-group">
+      <h3>Hurðir í B flokki:</h3>
+      <ul id="group-b-doors"></ul>
+    </div>
+    <div class="door-group">
+      <h3>Hurðir í C flokki:</h3>
+      <ul id="group-c-doors"></ul>
+    </div>
   </div>
 
   <script type="module" src="app.js"></script>

--- a/docs/src/styles.css
+++ b/docs/src/styles.css
@@ -44,6 +44,10 @@ select {
   margin-top: 0;
 }
 
+.door-group {
+  margin-bottom: 20px;
+}
+
 .door-list ul {
   list-style: none;
   padding: 0;

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -1,4 +1,4 @@
-import { updateColor } from '../src/updateColor.js';
+import { updateColor } from '../docs/src/updateColor.js';
 
 describe('updateColor', () => {
   test('sets provided color on element', () => {


### PR DESCRIPTION
## Summary
- Populate A, B, and C door lists on load so doors remain visible
- Add placeholder options and reset handler that clears selections and color boxes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688ff8271dec832680b0f0534982ea60