### PR TITLE
Display grouped door lists

### DIFF
--- a/docs/src/app.js
+++ b/docs/src/app.js
@@ -2,16 +2,62 @@ import { groups } from './data/groups.js';
 import { doors } from './data/Doorlist.js';
 import { updateColor } from './updateColor.js';
 
-document.addEventListener('DOMContentLoaded', () => {
-  const group1Select = document.getElementById('group1-select');
-  const group2Select = document.getElementById('group2-select');
-  const group3Select = document.getElementById('group3-select');
-  const group1Display = document.getElementById('group1-display');
-  const group2Display = document.getElementById('group2-display');
-  const group3Display = document.getElementById('group3-display');
-  const doorList = document.getElementById('door-list');
+const group1Select = document.getElementById('group1-select');
+const group2Select = document.getElementById('group2-select');
+const group3Select = document.getElementById('group3-select');
+const group1Display = document.getElementById('group1-display');
+const group2Display = document.getElementById('group2-display');
+const group3Display = document.getElementById('group3-display');
+const listAOnly = document.getElementById('group-a-only-doors');
+const listAB = document.getElementById('group-ab-doors');
+const listABC = document.getElementById('group-abc-doors');
 
+function populateDoorLists() {
+  const lists = { aOnly: listAOnly, ab: listAB, abc: listABC };
+  Object.values(lists).forEach((ul) => {
+    ul.innerHTML = '';
+  });
+
+  doors.forEach((door) => {
+    const hasA = door.groups.includes('a');
+    const hasB = door.groups.includes('b');
+    const hasC = door.groups.includes('c');
+
+    let key = null;
+    if (hasA && !hasB && !hasC) key = 'aOnly';
+    else if (hasA && hasB && !hasC) key = 'ab';
+    else if (hasA && hasB && hasC) key = 'abc';
+
+    if (key) {
+      const li = document.createElement('li');
+      li.textContent = door.label;
+      lists[key].appendChild(li);
+    }
+  });
+}
+
+function onGroupChange(select, display) {
+  const group = groups.find((g) => g.value === select.value);
+  updateColor(display, group && group.color);
+}
+
+function resetForm() {
   [group1Select, group2Select, group3Select].forEach((select) => {
+    select.value = '';
+  });
+
+  [group1Display, group2Display, group3Display].forEach((display) => {
+    updateColor(display, '');
+  });
+}
+
+function init() {
+  [group1Select, group2Select, group3Select].forEach((select) => {
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = '';
+    select.appendChild(placeholder);
+
     groups.forEach((group) => {
       const option = document.createElement('option');
       option.value = group.value;
@@ -20,66 +66,14 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 
-  function getSelectedGroups() {
-    return [group1Select.value, group2Select.value, group3Select.value].filter(Boolean);
-  }
-
-  function updateDoorList() {
-    const selected = getSelectedGroups();
-    const accessible = doors.filter((door) => door.groups.some((g) => selected.includes(g)));
-
-    doorList.innerHTML = '';
-    if (accessible.length === 0) {
-      const li = document.createElement('li');
-      li.textContent = 'Select groups to see doors';
-      doorList.appendChild(li);
-      return;
-    }
-
-    accessible.forEach((door) => {
-      const li = document.createElement('li');
-      li.textContent = door.label;
-
-      const indicators = document.createElement('span');
-      indicators.className = 'group-indicators';
-      door.groups.forEach((groupValue) => {
-        if (selected.includes(groupValue)) {
-          const g = groups.find((gr) => gr.value === groupValue);
-          const span = document.createElement('span');
-          span.style.backgroundColor = g.color;
-          indicators.appendChild(span);
-        }
-      });
-      li.appendChild(indicators);
-      doorList.appendChild(li);
-    });
-  }
-
-  function onGroupChange(select, display) {
-    const group = groups.find((g) => g.value === select.value);
-    updateColor(display, group && group.color);
-    updateDoorList();
-  }
-
   group1Select.addEventListener('change', () => onGroupChange(group1Select, group1Display));
   group2Select.addEventListener('change', () => onGroupChange(group2Select, group2Display));
   group3Select.addEventListener('change', () => onGroupChange(group3Select, group3Display));
 
+  populateDoorLists();
   resetForm();
+}
 
-  function resetForm() {
-    [group1Select, group2Select, group3Select].forEach((select) => {
-      select.selectedIndex = -1;
-    });
-
-    [group1Display, group2Display, group3Display].forEach((display) => {
-      display.className = 'color-box';
-      display.removeAttribute('style');
-    });
-
-    updateDoorList();
-  }
-
-  window.resetForm = resetForm;
-});
+init();
+window.resetForm = resetForm;
 

--- a/docs/src/index.html
+++ b/docs/src/index.html
@@ -33,7 +33,18 @@
 
   <div class="container door-list">
     <h2>Aðgengi:</h2>
-    <ul id="door-list"></ul>
+    <div class="door-group">
+      <h3>Hurðir með A aðgangi:</h3>
+      <ul id="group-a-only-doors"></ul>
+    </div>
+    <div class="door-group">
+      <h3>Hurðir með A og B aðgangi:</h3>
+      <ul id="group-ab-doors"></ul>
+    </div>
+    <div class="door-group">
+      <h3>Hurðir með A, B og C aðgangi:</h3>
+      <ul id="group-abc-doors"></ul>
+    </div>
   </div>
 
   <script type="module" src="app.js"></script>

--- a/docs/src/styles.css
+++ b/docs/src/styles.css
@@ -42,6 +42,13 @@ select {
 
 .door-list {
   margin-top: 0;
+  display: flex;
+  gap: 20px;
+  width: 900px;
+}
+
+.door-group {
+  flex: 1;
 }
 
 .door-list ul {

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -1,4 +1,4 @@
-import { updateColor } from '../src/updateColor.js';
+import { updateColor } from '../docs/src/updateColor.js';
 
 describe('updateColor', () => {
   test('sets provided color on element', () => {


### PR DESCRIPTION
## Summary
- Populate A-only, A+B, and A+B+C door lists and keep them always visible
- Present the door lists in three side-by-side columns by clearance level

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688ff8271dec832680b0f0534982ea60