### PR TITLE
Add simple client-side login gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,11 @@
 
 Static site for selecting user roles and door groups.
 
-The site is published via [GitHub Pages](https://shakypizza.github.io/AccessManager/src/index.html). If you receive a 404 error, ensure the URL uses the exact repository name with correct capitalization.
+The site is published via [GitHub Pages](https://shakypizza.github.io/AccessManager/). If you receive a 404 error,
+ ensure the URL uses the exact repository name with correct capitalization.
+
+## Login
+
+The GitHub Pages site uses a simple password gate. Visitors are first served `login.html` and redirected to the main
+interface after entering the correct password. The password entered by the user is hashed in the browser and compared
+against a stored hash.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="0; url=src/login.html">
+  <title>Redirecting</title>
+</head>
+<body>
+  <p>Redirecting to <a href="src/login.html">login</a>...</p>
+  <script>window.location.href = 'src/login.html';</script>
+</body>
+</html>

--- a/docs/src/index.html
+++ b/docs/src/index.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
+  <script>if (localStorage.getItem("authenticated") !== "true"){ window.location.href = "login.html"; }</script>
   <div class="container">
     <h1>Aðgangskerfi</h1>
 

--- a/docs/src/login.html
+++ b/docs/src/login.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Login</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Login</h1>
+    <form id="login-form">
+      <label for="password">Password:</label>
+      <input type="password" id="password" required />
+      <button type="submit">Enter</button>
+    </form>
+    <p id="error" class="error"></p>
+  </div>
+  <script type="module" src="login.js"></script>
+</body>
+</html>

--- a/docs/src/login.js
+++ b/docs/src/login.js
@@ -1,0 +1,21 @@
+const PASSWORD_HASH = '8a00e42690778ab9dbe36593c7722fb03e451fbc81dd14fecea8a4bd977dfd7e';
+
+async function sha256(str) {
+  const buffer = new TextEncoder().encode(str);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', buffer);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+document.getElementById('login-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const password = document.getElementById('password').value;
+  const hash = await sha256(password);
+  if (hash === PASSWORD_HASH) {
+    localStorage.setItem('authenticated', 'true');
+    window.location.href = 'index.html';
+  } else {
+    document.getElementById('error').textContent = 'Incorrect password';
+  }
+});


### PR DESCRIPTION
## Summary
- add password form and hashing script to gate access
- redirect GitHub Pages root to login screen and verify auth before loading app
- describe login workflow in README and set stored hash for password "krafla"

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689143f9bc708326bad80cabf44d9937