### PR TITLE
Add CI/CD deployment workflow with secret injection

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,19 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Inject password hash
+        run: |
+          sed -i "s|__PASSWORD_HASH__|${{ secrets.PASSWORD_HASH }}|g" docs/src/login.js
+
+      # Add your actual deploy steps below (e.g. copy files to server, S3, etc.)
+      # - name: Deploy to hosting
+      #   run: ...

--- a/docs/src/login.js
+++ b/docs/src/login.js
@@ -1,4 +1,4 @@
-const PASSWORD_HASH = '8a00e42690778ab9dbe36593c7722fb03e451fbc81dd14fecea8a4bd977dfd7e';
+const PASSWORD_HASH = '__PASSWORD_HASH__';
 
 async function sha256(str) {
   const buffer = new TextEncoder().encode(str);


### PR DESCRIPTION
## Summary
This PR introduces automated deployment infrastructure by adding a GitHub Actions workflow that securely injects sensitive credentials at build time, replacing hardcoded values in the codebase.

## Key Changes
- **Added GitHub Actions workflow** (`.github/workflows/deploy.yml`): Automatically triggers on pushes to `main` branch and injects the password hash secret into the login module before deployment
- **Externalized password hash** (`docs/src/login.js`): Replaced hardcoded password hash with a placeholder (`__PASSWORD_HASH__`) that gets substituted during the CI/CD pipeline

## Implementation Details
- The workflow uses `sed` to perform string replacement of the `__PASSWORD_HASH__` placeholder with the value stored in GitHub Secrets
- This approach keeps sensitive credentials out of version control while maintaining the ability to deploy with the correct values
- The workflow includes a commented template for actual deployment steps, allowing teams to customize their deployment targets (S3, servers, etc.)

https://claude.ai/code/session_01ShS5AQ8Dhny7EsNehgCEKW