### PR TITLE
Configure GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,9 +4,17 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
 
@@ -14,6 +22,11 @@ jobs:
         run: |
           sed -i "s|__PASSWORD_HASH__|${{ secrets.PASSWORD_HASH }}|g" docs/src/login.js
 
-      # Add your actual deploy steps below (e.g. copy files to server, S3, etc.)
-      # - name: Deploy to hosting
-      #   run: ...
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
Updated the deploy workflow to properly configure and deploy to GitHub Pages using official GitHub Actions.

## Key Changes
- Added required permissions for GitHub Pages deployment (`contents: read`, `pages: write`, `id-token: write`)
- Configured the deploy job with GitHub Pages environment settings and output URL
- Replaced placeholder deployment comments with actual GitHub Pages deployment steps:
  - Added `upload-pages-artifact` action to package the `docs` directory
  - Added `deploy-pages` action to deploy the artifact to GitHub Pages
  - Captured deployment URL output for workflow visibility

## Implementation Details
The workflow now follows GitHub's recommended approach for deploying static sites to GitHub Pages, with proper permission scoping and environment configuration for enhanced security and traceability.

https://claude.ai/code/session_01DpgCg6KXsPbtFpaw3huaud